### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ dgw    NodePort   10.43.20.141   <none>        80:31777/TCP,443:30000/TCP   78s
 44      - name: pvc-sdcard
 45        hostPath:
 46          path: /dgw/pvc-sdcard
-47          type: type: DirectoryOrCreate
+47          type: DirectoryOrCreate
 ```
 
 You can access Device Gateway's web console via Route:

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ cd takebishi-devicegateway-with-microshift/
 
 ```
 oc create -f manifest/namespace.yaml
-oc config set-context $(oc config current-context) --namespace=dgw
+sudo oc config set-context $(oc config current-context) --namespace=dgw
 ```
 
 ## Deploy Device Gateway

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ cd takebishi-devicegateway-with-microshift/
 
 ```
 oc create -f manifest/namespace.yaml
-sudo oc config set-context $(oc config current-context) --namespace=dgw
+oc config set-context $(oc config current-context) --namespace=dgw
 ```
 
 ## Deploy Device Gateway


### PR DESCRIPTION
removing duplicate type in volumes section for dgw/deployment if topolvm doesn't work.